### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/kafka/3-debian-10/Dockerfile
+++ b/kafka/3-debian-10/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kafka:3-debian-10
+FROM soldevelo/kafka:3.9.2-debian-12-r0
 
 LABEL author="xwi88" type="kafka" github="https://github.com/xwi88" group="https://github.com/v8fg"
 


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:3-debian-10` → [`soldevelo/kafka:3.9.2-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)